### PR TITLE
PLANNER-775: Workbench: Add scoreHolder global file to Planner kie-wb-playground projects

### DIFF
--- a/employee-rostering/src/main/resources/employeerostering/employeerostering/EmployeeRosterScoreHolderGlobal.gdrl
+++ b/employee-rostering/src/main/resources/employeerostering/employeerostering/EmployeeRosterScoreHolderGlobal.gdrl
@@ -15,6 +15,4 @@
 
 package employeerostering.employeerostering;
 
-import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScoreHolder;
-
-global HardSoftScoreHolder scoreHolder;
+global org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScoreHolder scoreHolder;

--- a/optacloud/src/main/resources/optacloud/optacloud/CloudSolutionScoreHolderGlobal.gdrl
+++ b/optacloud/src/main/resources/optacloud/optacloud/CloudSolutionScoreHolderGlobal.gdrl
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package optacloud.optacloud;
+
+global org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScoreHolder scoreHolder;

--- a/optacloud/src/main/resources/optacloud/optacloud/cloudScoreRules.drl
+++ b/optacloud/src/main/resources/optacloud/optacloud/cloudScoreRules.drl
@@ -16,12 +16,8 @@
 
 package optacloud.optacloud;
 
-import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScoreHolder;
-
 import optacloud.optacloud.Computer;
 import optacloud.optacloud.Process;
-
-global HardSoftScoreHolder scoreHolder;
 
 // ############################################################################
 // Hard constraints


### PR DESCRIPTION
This is required by https://issues.jboss.org/browse/PLANNER-350 to discover scoreHolder global in GRE.

@ge0ffrey Would you mind taking a look?