### PR TITLE
Explicitly specify kie-maven-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
       <plugin>
         <groupId>org.kie</groupId>
         <artifactId>kie-maven-plugin</artifactId>
+        <version>${version.org.kie}</version>
         <extensions>true</extensions>
       </plugin>
       <plugin>


### PR DESCRIPTION
The version needs to be set, otherwise Maven can choose whatever version
it sees fit. There are cases where Maven picks old 6.5.x version of the
plugin which is not compatible and causes build errors.