### PR TITLE
[DROOLS-1608] move processes related classes from drools to jbpm

### DIFF
--- a/evaluation/src/main/resources/WorkDefinitions.wid
+++ b/evaluation/src/main/resources/WorkDefinitions.wid
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.drools.core.process.core.datatype.impl.type.StringDataType;
+import org.jbpm.process.core.datatype.impl.type.StringDataType;
 [
   [
     "name" : "Email",

--- a/itorders/src/main/resources/org/jbpm/demo/itorders/WorkDefinition.wid
+++ b/itorders/src/main/resources/org/jbpm/demo/itorders/WorkDefinition.wid
@@ -1,5 +1,5 @@
-import org.drools.core.process.core.datatype.impl.type.StringDataType;
-import org.drools.core.process.core.datatype.impl.type.ObjectDataType;
+import org.jbpm.process.core.datatype.impl.type.StringDataType;
+import org.jbpm.process.core.datatype.impl.type.ObjectDataType;
 
 [
   [

--- a/itorders/src/main/resources/org/jbpm/demo/itorders/services/WorkDefinition.wid
+++ b/itorders/src/main/resources/org/jbpm/demo/itorders/services/WorkDefinition.wid
@@ -1,5 +1,5 @@
-import org.drools.core.process.core.datatype.impl.type.StringDataType;
-import org.drools.core.process.core.datatype.impl.type.ObjectDataType;
+import org.jbpm.process.core.datatype.impl.type.StringDataType;
+import org.jbpm.process.core.datatype.impl.type.ObjectDataType;
 
 [
   [


### PR DESCRIPTION
Example project `evaluation` and `itorders` can no longer be built after the renaming. This makes them buildable again