### PR TITLE
AF-593+: Move XStreamUtils to kie-soup.

### DIFF
--- a/employee-rostering/pom.xml
+++ b/employee-rostering/pom.xml
@@ -48,6 +48,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>
       <scope>provided</scope>

--- a/employee-rostering/src/main/java/employeerostering/employeerostering/DayOffRequest.java
+++ b/employee-rostering/src/main/java/employeerostering/employeerostering/DayOffRequest.java
@@ -26,7 +26,7 @@ public class DayOffRequest implements java.io.Serializable {
      *
      * @see <a href="https://github.com/x-stream/xstream/issues/75">XStream#75</a>
      */
-    @com.thoughtworks.xstream.annotations.XStreamConverter(org.kie.internal.xstream.LocalDateXStreamConverter.class)
+    @com.thoughtworks.xstream.annotations.XStreamConverter(org.kie.soup.commons.xstream.LocalDateXStreamConverter.class)
     private java.time.LocalDate date;
 
     public DayOffRequest() {

--- a/employee-rostering/src/main/java/employeerostering/employeerostering/Timeslot.java
+++ b/employee-rostering/src/main/java/employeerostering/employeerostering/Timeslot.java
@@ -25,9 +25,9 @@ public class Timeslot implements java.io.Serializable {
 
     static final long serialVersionUID = 1L;
 
-    @com.thoughtworks.xstream.annotations.XStreamConverter(org.kie.internal.xstream.LocalDateTimeXStreamConverter.class)
+    @com.thoughtworks.xstream.annotations.XStreamConverter(org.kie.soup.commons.xstream.LocalDateTimeXStreamConverter.class)
     private java.time.LocalDateTime startTime;
-    @com.thoughtworks.xstream.annotations.XStreamConverter(org.kie.internal.xstream.LocalDateTimeXStreamConverter.class)
+    @com.thoughtworks.xstream.annotations.XStreamConverter(org.kie.soup.commons.xstream.LocalDateTimeXStreamConverter.class)
     private java.time.LocalDateTime endTime;
 
     public Timeslot() {


### PR DESCRIPTION
Related:
https://github.com/kiegroup/kie-soup/pull/9
https://github.com/AppFormer/uberfire/pull/890
https://github.com/kiegroup/drools/pull/1562
https://github.com/kiegroup/jbpm/pull/1047
https://github.com/kiegroup/droolsjbpm-knowledge/pull/277
https://github.com/kiegroup/droolsjbpm-integration/pull/1248
https://github.com/kiegroup/kie-wb-common/pull/1269
https://github.com/kiegroup/drools-wb/pull/675
https://github.com/kiegroup/optaplanner-wb/pull/234
https://github.com/kiegroup/kie-wb-playground/pull/43