### PR TITLE
AF-1129: Fix invalid project names

### DIFF
--- a/curriculumcourse/pom.xml
+++ b/curriculumcourse/pom.xml
@@ -34,7 +34,7 @@
   </parent>
   <artifactId>curriculumcourse</artifactId>
   <packaging>kjar</packaging>
-  <name>Course Scheduling</name>
+  <name>Course_Scheduling</name>
   <description>University course scheduling using Planner. Assigns lectures to rooms.</description>
   <dependencies>
     <dependency>

--- a/dinnerparty/pom.xml
+++ b/dinnerparty/pom.xml
@@ -34,7 +34,7 @@
   </parent>
   <artifactId>dinnerparty</artifactId>
   <packaging>kjar</packaging>
-  <name>Dinner Party</name>
+  <name>Dinner_Party</name>
   <description>Guest seating optimisation using Planner. Leverages Guided Decision Tables to define scoring function.</description>
   <dependencies>
     <dependency>

--- a/employee-rostering/pom.xml
+++ b/employee-rostering/pom.xml
@@ -34,7 +34,7 @@
   </parent>
   <artifactId>employeerostering</artifactId>
   <packaging>kjar</packaging>
-  <name>Employee Rostering</name>
+  <name>Employee_Rostering</name>
   <description>Employee rostering problem optimisation using Planner. Assigns employees to shifts based on their skill.</description>
   <dependencies>
     <dependency>

--- a/evaluation/pom.xml
+++ b/evaluation/pom.xml
@@ -34,7 +34,7 @@
   </parent>
   <artifactId>evaluation</artifactId>
   <packaging>kjar</packaging>
-  <name>Evaluation Process</name>
+  <name>Evaluation_Process</name>
   <description>Getting started Business Process for evaluating employees</description>
 
   <build>

--- a/itorders/pom.xml
+++ b/itorders/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <artifactId>itorders</artifactId>  
   <packaging>kjar</packaging>
-  <name>IT Orders</name>
+  <name>IT_Orders</name>
   <description>Case Management IT Orders project</description>
   <build>
     <plugins>


### PR DESCRIPTION
FYI @tiagobento after https://github.com/kiegroup/kie-wb-common/pull/1664 has been merged, all the example project names containing spaces are highlighted as invalid.

To reproduce this just import "Evaluation process" in kie-wb, go to project settings, do any change and try to save -> you'll get invalid project name validation error.

I propose this fix by replacing all spaces in project names by underscores.