### PR TITLE
[AF-1124]: Added Mandatory Dependencies to Playground

### DIFF
--- a/kie-all-playground/src/main/xslt/dependencies.xml
+++ b/kie-all-playground/src/main/xslt/dependencies.xml
@@ -1,0 +1,55 @@
+<!--
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<dependencies>
+  <dependency>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-api</artifactId>
+    <version>${version.org.kie}</version>
+    <scope>provided</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-internal</artifactId>
+    <version>${version.org.kie}</version>
+    <scope>provided</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-core</artifactId>
+    <version>${version.org.kie}</version>
+    <scope>provided</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-persistence-jaxb</artifactId>
+    <version>${version.org.kie}</version>
+    <scope>provided</scope>
+  </dependency>
+  <dependency>
+    <groupId>junit</groupId>
+    <artifactId>junit</artifactId>
+    <version>4.12</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.thoughtworks.xstream</groupId>
+    <artifactId>xstream</artifactId>
+    <version>1.4.10</version>
+    <scope>test</scope>
+  </dependency>
+</dependencies>

--- a/kie-all-playground/src/main/xslt/stylesheet-kie-all-playground.xsl
+++ b/kie-all-playground/src/main/xslt/stylesheet-kie-all-playground.xsl
@@ -21,6 +21,9 @@
                 exclude-result-prefixes="m xalan"
                 version="1.0">
 
+
+  <xsl:variable name="dependencies" select="document('dependencies.xml')"/>
+
   <!-- Remove all whitespaces & format the output -->
   <xsl:strip-space elements="*"/>
   <xsl:output method="xml" indent="yes" xalan:indent-amount="2"/>
@@ -32,15 +35,31 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- Remove parent & dependencies declarations -->
+  <!-- Remove parent & and commets-->
   <xsl:template match="m:parent"/>
-  <xsl:template match="m:dependencies"/>
   <xsl:template match="comment()[contains(., 'The file is modified by XSL transformation before kie-wb-playground.zip file is created.')]"/>
+
+  <!-- Replace dependencies with mandatories -->
+
+  <xsl:template match="m:project[not(m:dependencies)]">
+    <xsl:copy>
+      <xsl:apply-templates select="node() | @*"/>
+      <xsl:copy-of select="$dependencies/dependencies"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="m:dependencies">
+    <xsl:copy>
+      <xsl:copy-of select="$dependencies/dependencies/dependency"/>
+    </xsl:copy>
+  </xsl:template>
 
   <!-- Set version to 1.0.0-SNAPSHOT -->
   <xsl:template match="m:project/m:artifactId">
     <xsl:copy-of select="."/>
-    <groupId><xsl:value-of select="current()"/></groupId>
+    <groupId>
+      <xsl:value-of select="current()"/>
+    </groupId>
     <version>1.0.0-SNAPSHOT</version>
   </xsl:template>
 

--- a/kie-decision-playground/src/main/xslt/dependencies.xml
+++ b/kie-decision-playground/src/main/xslt/dependencies.xml
@@ -1,0 +1,55 @@
+<!--
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<dependencies>
+  <dependency>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-api</artifactId>
+    <version>${version.org.kie}</version>
+    <scope>provided</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-internal</artifactId>
+    <version>${version.org.kie}</version>
+    <scope>provided</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-core</artifactId>
+    <version>${version.org.kie}</version>
+    <scope>provided</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.optaplanner</groupId>
+    <artifactId>optaplanner-persistence-jaxb</artifactId>
+    <version>${version.org.kie}</version>
+    <scope>provided</scope>
+  </dependency>
+  <dependency>
+    <groupId>junit</groupId>
+    <artifactId>junit</artifactId>
+    <version>4.12</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.thoughtworks.xstream</groupId>
+    <artifactId>xstream</artifactId>
+    <version>1.4.10</version>
+    <scope>test</scope>
+  </dependency>
+</dependencies>

--- a/kie-decision-playground/src/main/xslt/stylesheet-kie-decision-playground.xsl
+++ b/kie-decision-playground/src/main/xslt/stylesheet-kie-decision-playground.xsl
@@ -21,6 +21,9 @@
                 exclude-result-prefixes="m xalan"
                 version="1.0">
 
+
+  <xsl:variable name="dependencies" select="document('dependencies.xml')"/>
+
   <!-- Remove all whitespaces & format the output -->
   <xsl:strip-space elements="*"/>
   <xsl:output method="xml" indent="yes" xalan:indent-amount="2"/>
@@ -32,15 +35,31 @@
     </xsl:copy>
   </xsl:template>
 
-  <!-- Remove parent & dependencies declarations -->
+  <!-- Remove parent & and commets-->
   <xsl:template match="m:parent"/>
-  <xsl:template match="m:dependencies"/>
   <xsl:template match="comment()[contains(., 'The file is modified by XSL transformation before kie-wb-playground.zip file is created.')]"/>
+
+  <!-- Replace dependencies with mandatories -->
+
+  <xsl:template match="m:project[not(m:dependencies)]">
+    <xsl:copy>
+      <xsl:apply-templates select="node() | @*"/>
+      <xsl:copy-of select="$dependencies/dependencies"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="m:dependencies">
+    <xsl:copy>
+      <xsl:copy-of select="$dependencies/dependencies/dependency"/>
+    </xsl:copy>
+  </xsl:template>
 
   <!-- Set version to 1.0.0-SNAPSHOT -->
   <xsl:template match="m:project/m:artifactId">
     <xsl:copy-of select="."/>
-    <groupId><xsl:value-of select="current()"/></groupId>
+    <groupId>
+      <xsl:value-of select="current()"/>
+    </groupId>
     <version>1.0.0-SNAPSHOT</version>
   </xsl:template>
 


### PR DESCRIPTION
XSLTs adds mandatory dependencies to playground poms. This is required by the new Import validator

Cherry picked from: https://github.com/kiegroup/kie-wb-playground/pull/64
