### PR TITLE
[7.7.x] RHPAM-1221: fix names of sample projects

### DIFF
--- a/curriculumcourse/pom.xml
+++ b/curriculumcourse/pom.xml
@@ -34,7 +34,7 @@
   </parent>
   <artifactId>curriculumcourse</artifactId>
   <packaging>kjar</packaging>
-  <name>Course Scheduling</name>
+  <name>Course_Scheduling</name>
   <description>University course scheduling using Planner. Assigns lectures to rooms.</description>
   <dependencies>
     <dependency>

--- a/dinnerparty/pom.xml
+++ b/dinnerparty/pom.xml
@@ -34,7 +34,7 @@
   </parent>
   <artifactId>dinnerparty</artifactId>
   <packaging>kjar</packaging>
-  <name>Dinner Party</name>
+  <name>Dinner_Party</name>
   <description>Guest seating optimisation using Planner. Leverages Guided Decision Tables to define scoring function.</description>
   <dependencies>
     <dependency>

--- a/employee-rostering/pom.xml
+++ b/employee-rostering/pom.xml
@@ -34,7 +34,7 @@
   </parent>
   <artifactId>employeerostering</artifactId>
   <packaging>kjar</packaging>
-  <name>Employee Rostering</name>
+  <name>Employee_Rostering</name>
   <description>Employee rostering problem optimisation using Planner. Assigns employees to shifts based on their skill.</description>
   <dependencies>
     <dependency>

--- a/evaluation/pom.xml
+++ b/evaluation/pom.xml
@@ -34,7 +34,7 @@
   </parent>
   <artifactId>evaluation</artifactId>
   <packaging>kjar</packaging>
-  <name>Evaluation Process</name>
+  <name>Evaluation_Process</name>
   <description>Getting started Business Process for evaluating employees</description>
 
   <build>

--- a/itorders/pom.xml
+++ b/itorders/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <artifactId>itorders</artifactId>  
   <packaging>kjar</packaging>
-  <name>IT Orders</name>
+  <name>IT_Orders</name>
   <description>Case Management IT Orders project</description>
   <build>
     <plugins>

--- a/mortgage-process/pom.xml
+++ b/mortgage-process/pom.xml
@@ -26,7 +26,7 @@
   </parent>
   <artifactId>mortgage-process</artifactId>
   <packaging>kjar</packaging>
-  <name>Mortgage Process</name>
+  <name>Mortgage_Process</name>
   <description>Getting started loan approval process in BPMN2, decision table, business rules, and forms.</description>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Making project names of sample projects valid  after project name validation was implemented. See [RHPAM-1221](https://issues.jboss.org/browse/RHPAM-1221) for details. @manstis can you please check?